### PR TITLE
Fix zone::ListZones endpoint

### DIFF
--- a/cloudflare/src/endpoints/account/mod.rs
+++ b/cloudflare/src/endpoints/account/mod.rs
@@ -15,9 +15,9 @@ pub struct Account {
     /// Account name
     pub name: String,
     /// Account Settings
-    pub settings: Settings,
+    pub settings: Option<Settings>,
     /// describes when the account was created
-    pub created_on: DateTime<Utc>,
+    pub created_on: Option<DateTime<Utc>>,
 }
 
 /// Cloudflare Accounts Settings

--- a/cloudflare/src/endpoints/plan.rs
+++ b/cloudflare/src/endpoints/plan.rs
@@ -1,6 +1,8 @@
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "lowercase")]
 pub enum Frequency {
+    #[serde(rename = "")]
+    Nil,
     Weekly,
     Monthly,
     Quarterly,

--- a/cloudflare/src/endpoints/zone.rs
+++ b/cloudflare/src/endpoints/zone.rs
@@ -10,15 +10,18 @@ use chrono::DateTime;
 /// List Zones
 /// List, search, sort, and filter your zones
 /// https://api.cloudflare.com/#zone-list-zones
-pub struct ListZones<'a> {
-    pub identifier: &'a str,
+pub struct ListZones {
+    pub params: ListZonesParams,
 }
-impl<'a> Endpoint<Vec<Zone>, ListZonesParams> for ListZones<'a> {
+impl Endpoint<Vec<Zone>, ListZonesParams> for ListZones {
     fn method(&self) -> Method {
         Method::Get
     }
     fn path(&self) -> String {
         "zones".to_string()
+    }
+    fn query(&self) -> Option<ListZonesParams> {
+        Some(self.params.clone())
     }
 }
 
@@ -154,7 +157,7 @@ pub struct Zone {
     pub status: Status,
     /// An array of domains used for custom name servers. This is only available for Business and
     /// Enterprise plans.
-    pub vanity_name_servers: Vec<String>,
+    pub vanity_name_servers: Option<Vec<String>>,
     /// A full zone implies that DNS is hosted with Cloudflare. A partial zone is typically a
     /// partner-hosted zone or a CNAME setup.
     #[serde(rename = "type")]


### PR DESCRIPTION
Various fixes in the path of getting the ListZones endpoint to work:

- Use ListZonesParams for query in ListZones requests (fixes #75)
- Fix fields that should be optional
- Correctly deserialize empty plan frequency (fixes #8)